### PR TITLE
include babel-eslint - fixes #4

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   ],
   "homepage": "https://github.com/eventualbuddha/rollup-starter-project#readme",
   "devDependencies": {
+    "babel-eslint": "^5.0.0-beta4",
     "babel-preset-es2015-rollup": "^1.0.0",
     "eslint": "^1.2.0",
     "mocha": "^2.2.5",


### PR DESCRIPTION
Adding `babel-eslint` made `rollup-starter-project   build.